### PR TITLE
Fixed Imports (socketserver -> SocketServer)

### DIFF
--- a/streamparse/contextmanagers.py
+++ b/streamparse/contextmanagers.py
@@ -4,8 +4,10 @@ import subprocess
 import time
 from contextlib import contextmanager
 from socket import error as SocketError
+from SocketServer import UDPServer, TCPServer
 
-from six.moves.socketserver import UDPServer, TCPServer
+#Python 2.7+ does not recognize 'socketserver'
+#from six.moves.socketserver import UDPServer, TCPServer
 
 
 def _port_in_use(port, server_type="tcp"):


### PR DESCRIPTION
Imports UDPServer, TCPServer from SocketServer rather than socketserver. Python2.7 won't recognize six.moves.socketserver.
